### PR TITLE
Avoid unnecessary copying of files and remove suffix of executable files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ Done! after reboot you will be using intel/nvidia prime.
 To change the default mode to intel only, run:
 
 ```bash
-sudo set-intel.sh
+sudo set-intel
 ```
 
 To switch the default mode to intel/nvidia prime, run: 
 
 ```bash
-sudo set-nvidia.sh
+sudo set-nvidia
 ```
 
 Done!
@@ -114,7 +114,7 @@ At the bottom you will see 2 lines #commented out, uncomment them (remove #) and
 Then:
 
 ```bash
-sudo set-intel.sh
+sudo set-intel
 reboot
 ```
 
@@ -126,8 +126,8 @@ Only errors after "copying" starts should be of any concern. If you could save t
 
 ### Usage after running install script:  
 
-- `sudo set-intel.sh` will set intel only mode, reboot and nvidia powered off and removed from view.
-- `sudo set-nvidia.sh`  sets intel/nvidia (prime) mode.
+- `sudo set-intel` will set intel only mode, reboot and nvidia powered off and removed from view.
+- `sudo set-nvidia`  sets intel/nvidia (prime) mode.
 
 This should be pretty straight forward, if however, you cant figure it out, i am @dglt on the manjaro forum. i hope this is as useful for you as it is for me.
 

--- a/install.sh
+++ b/install.sh
@@ -55,9 +55,9 @@ rm -rf /usr/local/share/optimus.desktop
 echo 'rm -rf /usr/local/share/optimus.desktop'
 sleep 2
 
-echo 'Copying contents of ~/optimus-switch/* to /etc/ .......'
+echo 'Copying contents of ~/optimus-switch/switch/* to /etc/switch/ .......'
 mkdir /etc/switch/
-cp -r * /etc/
+cp -r ~/optimus-switch/switch/* /etc/switch/
 mkdir /etc/lightdm/lightdm.conf.d
 cp /etc/switch/lightdm.conf /etc/lightdm/lightdm.conf.d/lightdm.conf
 sleep 2

--- a/install.sh
+++ b/install.sh
@@ -63,9 +63,9 @@ cp /etc/switch/lightdm.conf /etc/lightdm/lightdm.conf.d/lightdm.conf
 sleep 2
 echo 'Copying set-intel.sh and set-nvidia.sh to /usr/local/bin/'
 
-cp /etc/switch/set-intel.sh /usr/local/bin/set-intel.sh
+cp /etc/switch/set-intel.sh /usr/local/bin/set-intel
 
-cp /etc/switch/set-nvidia.sh /usr/local/bin/set-nvidia.sh
+cp /etc/switch/set-nvidia.sh /usr/local/bin/set-nvidia
 
 ###This section not needed for LightDM but can be used if want, its not required.
 #cp /etc/switch/optimus.desktop /usr/local/share/optimus.desktop
@@ -76,26 +76,26 @@ cp /etc/switch/set-nvidia.sh /usr/local/bin/set-nvidia.sh
 #chmod 644 /etc/systemd/system/disable-nvidia.service
 
 sleep 1
-echo 'Setting nvidia prime mode (sudo set-nvidia.sh).......'
+echo 'Setting nvidia prime mode (sudo set-nvidia).......'
 
 cp /etc/switch/nvidia/nvidia-xorg.conf /etc/X11/xorg.conf.d/99-nvidia.conf
 cp /etc/switch/nvidia/nvidia-modprobe.conf /etc/modprobe.d/99-nvidia.conf
 cp /etc/switch/nvidia/nvidia-modules.conf /etc/modules-load.d/99-nvidia.conf
-cp /etc/switch/nvidia/optimus.sh /usr/local/bin/optimus.sh
+cp /etc/switch/nvidia/optimus.sh /usr/local/bin/optimus
 
 sleep 1
 echo 'Setting permissions........'
-chmod +x /usr/local/bin/set-intel.sh
-chmod +x /usr/local/bin/set-nvidia.sh
-chmod a+rx /usr/local/bin/optimus.sh
+chmod +x /usr/local/bin/set-intel
+chmod +x /usr/local/bin/set-nvidia
+chmod a+rx /usr/local/bin/optimus
 chmod a+rx /etc/switch/intel/no-optimus.sh
 chmod a+rx /etc/switch/nvidia/optimus.sh
 chmod +x /etc/switch/gpu_switch_check.sh
 
 sleep 1
 echo 'Currently boot mode is set to nvidia prime.'
-echo 'you can switch to intel only mode with sudo set-intel.sh and reboot.'
-echo 'same can be done for nvidia prime mode with sudo set-nvidia.sh'
+echo 'you can switch to intel only mode with sudo set-intel and reboot.'
+echo 'same can be done for nvidia prime mode with sudo set-nvidia'
 
 sleep 1
 echo 'this updated installer no longer requires manually editing lightdm.conf'


### PR DESCRIPTION
It's unnecessary to copy `~/optimus-switch/*` to `/etc/`. What's more, some executable files copied to `/usr/local/bin/` should only be kept with their basenames.